### PR TITLE
Use PR number for test deploy

### DIFF
--- a/cloudbuild_test.yaml
+++ b/cloudbuild_test.yaml
@@ -21,5 +21,5 @@ steps:
 
   - name: "gcr.io/cloud-builders/gcloud"
     id: Deploy service for testing
-    args: ["app", "deploy", "--version", "$BRANCH_NAME-test", "--no-promote"]
+    args: ["app", "deploy", "--version", "pull-request-number-$_PR_NUMBER-test", "--no-promote"]
     timeout: "1600s"


### PR DESCRIPTION
App engine will not allow upper case letters or underscores in the version name, using the pull request number to name the test versions instead