### PR TITLE
Tidy old Versions

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -30,12 +30,11 @@ steps:
     args:
       - '-c'
       - |
-        <<-EOF
-          VERSIONS=$(gcloud app versions list --service tobi-ui --sort-by '~version' --format 'value(version.id)' | sort -r | tail -n +10 | paste -sd " " -)
-          if [ ${#VERSIONS} -gt 0 ]
-          then
-            gcloud app versions delete --service tobi-ui $VERSIONS -q
-          else
-            echo "No Versions to Clean Up"
-          fi
-        EOF
+        VERSIONS=$(gcloud app versions list --service tobi-ui --sort-by '~version' --format 'value(version.id)' | sort -r | tail -n +10 | paste -sd " " -)
+        if [ ${#VERSIONS} -gt 0 ]
+        then
+          gcloud app versions delete --service tobi-ui $VERSIONS -q
+        else
+          echo "No Versions to Clean Up"
+        fi
+        

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -23,3 +23,19 @@ steps:
     id: Deploy service
     args: ["app", "deploy"]
     timeout: "1600s"
+
+  - name: 'gcr.io/cloud-builders/gcloud'
+    id: Clean up old Versions
+    entrypoint: 'bash'
+    args:
+      - '-c'
+      - |
+        <<-EOF
+          VERSIONS=$(gcloud app versions list --service tobi-ui --sort-by '~version' --format 'value(version.id)' | sort -r | tail -n +10 | paste -sd " " -)
+          if [ ${#VERSIONS} -gt 0 ]
+          then
+            gcloud app versions delete --service tobi-ui $VERSIONS -q
+          else
+            echo "No Versions to Clean Up"
+          fi
+        EOF

--- a/cloudbuild_test.yaml
+++ b/cloudbuild_test.yaml
@@ -9,7 +9,7 @@ steps:
         echo $VERSIONS
         if [ ${#VERSIONS} -gt 0 ]
         then
-          gcloud app versions delete --service 'tobi-ui' $VERSIONS -q
+          echo "We Trigger this statement"
         else
           echo "No Versions to Clean Up"
         fi

--- a/cloudbuild_test.yaml
+++ b/cloudbuild_test.yaml
@@ -5,17 +5,15 @@ steps:
     args:
       - '-c'
       - |
-        VERSIONS=$(gcloud app versions list --service tobi-ui --sort-by '~version' --format 'value(version.id)')
-        COUNT=0
-        echo "Keeping the 10 latest versions of the tobi-ui service"
-        for VERSION in $VERSIONS
-        do
-          ((COUNT++))
-          if [ $COUNT -gt 10 ]
-          then
-            echo "Going to delete version $VERSION of the tobi-ui service."
-            gcloud app versions delete $VERSION --service tobi-ui -q
-          else
-            echo "Going to keep version $VERSION of the tobi-ui service."
-          fi
-        done
+        versions=$(gcloud app versions list \
+          --service tobi-ui \
+          --sort-by '~version' \
+          --format 'value(VERSION.ID)' \
+          --project ${PROJECT_ID} | tail -n +10)
+
+        if [ -n "$versions" ]; then
+          gcloud app versions delete "$versions"
+            --service default
+            --project ${PROJECT_ID}
+            --quiet
+        fi

--- a/cloudbuild_test.yaml
+++ b/cloudbuild_test.yaml
@@ -23,3 +23,19 @@ steps:
     id: Deploy service for testing
     args: ["app", "deploy", "--version", "pull-request-number-$_PR_NUMBER-test", "--no-promote"]
     timeout: "1600s"
+
+  - name: 'gcr.io/cloud-builders/gcloud'
+    id: Clean up old Versions
+    entrypoint: 'bash'
+    args:
+      - '-c'
+      - |
+        <<-EOF
+          VERSIONS=$(gcloud app versions list --service tobi-ui --sort-by '~version' --format 'value(version.id)' | sort -r | tail -n +10 | paste -sd " " -)
+          if [ ${#VERSIONS} -gt 0 ]
+          then
+            gcloud app versions delete --service tobi-ui $VERSIONS -q
+          else
+            echo "No Versions to Clean Up"
+          fi
+        EOF

--- a/cloudbuild_test.yaml
+++ b/cloudbuild_test.yaml
@@ -5,11 +5,7 @@ steps:
     args:
       - '-c'
       - |
-        versions=$(gcloud app versions list \
-          --service tobi-ui \
-          --sort-by '~version' \
-          --format 'value(VERSION.ID)' \
-          --project ${PROJECT_ID} | tail -n +10)
+        versions=$(gcloud app versions list --service tobi-ui --sort-by '~version' --format 'value(VERSION.ID)' --project ${PROJECT_ID} | tail -n +11)
 
         if [ -n "$versions" ]; then
           gcloud app versions delete "$versions"

--- a/cloudbuild_test.yaml
+++ b/cloudbuild_test.yaml
@@ -5,11 +5,11 @@ steps:
     args:
       - '-c'
       - |
-        VERSIONS=$(gcloud app versions list --service tobi-ui --sort-by '~version' --format 'value(version.id)' | sort -r | tail -n +10 | paste -sd " " -)
+        VERSIONS=$(gcloud app versions list --service 'tobi-ui' --sort-by '~version' --format 'value(version.id)' | sort -r | tail -n +10 | paste -sd " " -)
         echo $VERSIONS
         if [ ${#VERSIONS} -gt 0 ]
         then
-          gcloud app versions delete --service tobi-ui $VERSIONS -q
+          gcloud app versions delete --service 'tobi-ui' $VERSIONS -q
         else
           echo "No Versions to Clean Up"
         fi

--- a/cloudbuild_test.yaml
+++ b/cloudbuild_test.yaml
@@ -8,9 +8,3 @@ steps:
         gcloud app versions list --service 'tobi-ui' --sort-by '~version' --format 'value(version.id)' | sort -r | tail -n +10 | paste -sd " " -
         VERSIONS=$(gcloud app versions list --service 'tobi-ui' --sort-by '~version' --format 'value(version.id)' | sort -r | tail -n +10 | paste -sd " " -)
         echo $VERSIONS
-        if [ ${#VERSIONS} -gt 0 ]
-        then
-          gcloud app versions delete --service 'tobi-ui' $VERSIONS -q
-        else
-          echo "No Versions to Clean Up"
-        fi

--- a/cloudbuild_test.yaml
+++ b/cloudbuild_test.yaml
@@ -5,11 +5,12 @@ steps:
     args:
       - '-c'
       - |
+        gcloud app versions list --service 'tobi-ui' --sort-by '~version' --format 'value(version.id)' | sort -r | tail -n +10 | paste -sd " " -
         VERSIONS=$(gcloud app versions list --service 'tobi-ui' --sort-by '~version' --format 'value(version.id)' | sort -r | tail -n +10 | paste -sd " " -)
         echo $VERSIONS
         if [ ${#VERSIONS} -gt 0 ]
         then
-          echo "We Trigger this statement"
+          gcloud app versions delete --service 'tobi-ui' $VERSIONS -q
         else
           echo "No Versions to Clean Up"
         fi

--- a/cloudbuild_test.yaml
+++ b/cloudbuild_test.yaml
@@ -1,30 +1,5 @@
 steps:
   - name: 'gcr.io/cloud-builders/gcloud'
-    id: Generate manifest
-    entrypoint: 'bash'
-    args:
-      - '-c'
-      - |
-        sed "s#_PROJECT_ID#${_PROJECT_ID}#g" appengine_templates/app.yaml.tpl | \
-        sed "s#_VM_INTERNAL_URL#${_VM_INTERNAL_URL}#g" | \
-        sed "s#_VM_EXTERNAL_WEB_URL#${_VM_EXTERNAL_WEB_URL}#g" | \
-        sed "s#_VM_EXTERNAL_CLIENT_URL#${_VM_EXTERNAL_CLIENT_URL}#g" | \
-        sed "s#_BLAISE_API_URL#${_BLAISE_API_URL}#g" > app.yaml
-
-  - name: 'gcr.io/cloud-builders/gcloud'
-    id: Print Output
-    entrypoint: /bin/sh
-    args:
-      - '-c'
-      - |
-        cat app.yaml
-
-  - name: "gcr.io/cloud-builders/gcloud"
-    id: Deploy service for testing
-    args: ["app", "deploy", "--version", "pull-request-number-$_PR_NUMBER-test", "--no-promote"]
-    timeout: "1600s"
-
-  - name: 'gcr.io/cloud-builders/gcloud'
     id: Clean up old Versions
     entrypoint: 'bash'
     args:

--- a/cloudbuild_test.yaml
+++ b/cloudbuild_test.yaml
@@ -5,6 +5,17 @@ steps:
     args:
       - '-c'
       - |
-        gcloud app versions list --service 'tobi-ui' --sort-by '~version' --format 'value(version.id)' | sort -r | tail -n +10 | paste -sd " " -
-        VERSIONS=$(gcloud app versions list --service 'tobi-ui' --sort-by '~version' --format 'value(version.id)' | sort -r | tail -n +10 | paste -sd " " -)
-        echo $VERSIONS
+        VERSIONS=$(gcloud app versions list --service tobi-ui --sort-by '~version' --format 'value(version.id)')
+        COUNT=0
+        echo "Keeping the 10 latest versions of the tobi-ui service"
+        for VERSION in $VERSIONS
+        do
+          ((COUNT++))
+          if [ $COUNT -gt 10 ]
+          then
+            echo "Going to delete version $VERSION of the tobi-ui service."
+            gcloud app versions delete $VERSION --service tobi-ui -q
+          else
+            echo "Going to keep version $VERSION of the tobi-ui service."
+          fi
+        done

--- a/cloudbuild_test.yaml
+++ b/cloudbuild_test.yaml
@@ -30,12 +30,10 @@ steps:
     args:
       - '-c'
       - |
-        <<-EOF
-          VERSIONS=$(gcloud app versions list --service tobi-ui --sort-by '~version' --format 'value(version.id)' | sort -r | tail -n +10 | paste -sd " " -)
-          if [ ${#VERSIONS} -gt 0 ]
-          then
-            gcloud app versions delete --service tobi-ui $VERSIONS -q
-          else
-            echo "No Versions to Clean Up"
-          fi
-        EOF
+        VERSIONS=$(gcloud app versions list --service tobi-ui --sort-by '~version' --format 'value(version.id)' | sort -r | tail -n +10 | paste -sd " " -)
+        if [ ${#VERSIONS} -gt 0 ]
+        then
+          gcloud app versions delete --service tobi-ui $VERSIONS -q
+        else
+          echo "No Versions to Clean Up"
+        fi

--- a/cloudbuild_test.yaml
+++ b/cloudbuild_test.yaml
@@ -31,6 +31,7 @@ steps:
       - '-c'
       - |
         VERSIONS=$(gcloud app versions list --service tobi-ui --sort-by '~version' --format 'value(version.id)' | sort -r | tail -n +10 | paste -sd " " -)
+        echo $VERSIONS
         if [ ${#VERSIONS} -gt 0 ]
         then
           gcloud app versions delete --service tobi-ui $VERSIONS -q

--- a/cloudbuild_test.yaml
+++ b/cloudbuild_test.yaml
@@ -5,7 +5,7 @@ steps:
     args:
       - '-c'
       - |
-        versions=$(gcloud app versions list --service tobi-ui --sort-by '~version' --format 'value(VERSION.ID)' --project ${PROJECT_ID} | tail -n +11)
+        versions=$(gcloud app versions list --service=tobi-ui --sort-by='~version' --format='value(VERSION.ID)' --project=${PROJECT_ID} | tail -n +11)
 
         if [ -n "$versions" ]; then
           gcloud app versions delete "$versions"


### PR DESCRIPTION
This code at the end of the cloudbuild job should delete old versions of the particular service.
The code itself was find here: https://gist.github.com/vonNiklasson/b9d3c64ec8beb6a13a42e647012d4815 and modified to set the max versions to 10 and to echo back that there are no versions to delete if it found nothing.