### PR TITLE
nodejs14 now GA

### DIFF
--- a/appengine_templates/app.yaml.tpl
+++ b/appengine_templates/app.yaml.tpl
@@ -1,5 +1,5 @@
 service: tobi-ui
-runtime: nodejs12
+runtime: nodejs14
 
 vpc_access_connector:
   name: projects/_PROJECT_ID/locations/europe-west2/connectors/vpcconnect


### PR DESCRIPTION
As nodejs14 is now GA on GAE this change updates the runtime.